### PR TITLE
Set user to www-data to run database setup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,11 @@ RUN apt-get -y install curl
 # set workdir
 WORKDIR /var/www/html/
 
+# set user to own database
+USER www-data
+
 # create database
 RUN php -f setup.php
+
+# set user to start apache
+USER root


### PR DESCRIPTION
Currently the database setup is run as `root`. This causes an error when Apache tries to write to the database as `www-data`. This change sets the user to `www-data` to setup the database and back to `root` to start the Apache service.

Alternatively you could `chown` or `chmod` the `.sqlite` file after running the setup. Up to you.